### PR TITLE
Use forked version of ruby-kafka to address Kafka::MessageSizeTooLarge.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,5 +2,9 @@ source "https://rubygems.org"
 
 git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
 
+# This should only be temporary until we everything gets merged in upstream.
+gem 'ruby-kafka', git: 'https://github.com/OneSignal/ruby-kafka', branch: 'patch/v0.7.6-message-size-too-large', ref: '1c264d5b20875966a7888b42df9df4ba50fd490b'
+
+
 # Specify your gem's dependencies in delivery_boy.gemspec
 gemspec


### PR DESCRIPTION
This simply just updates the ruby-kafka version to point to this branch:
https://github.com/OneSignal/ruby-kafka/tree/patch/v0.7.6-message-size-too-large

For reference, the code review will happen on this PR:
https://github.com/OneSignal/ruby-kafka/pull/1